### PR TITLE
FIX: Resolve deployment issues

### DIFF
--- a/aws_secret_store/main.tf
+++ b/aws_secret_store/main.tf
@@ -88,6 +88,6 @@ data "aws_iam_policy_document" "secret_retrieval_policy_doc" {
 
 resource "aws_iam_policy" "secret_retrieval_policies" {
   count  = "${length(var.environments)}"
-  name   = "${var.namespace}-${var.environments[count.index]}-secret_retrieval"
+  name   = "${var.namespace}-${var.environments[count.index]}-secret-retrieval"
   policy = "${data.aws_iam_policy_document.secret_retrieval_policy_doc.*.json[count.index]}"
 }

--- a/aws_secret_store/main.tf
+++ b/aws_secret_store/main.tf
@@ -88,6 +88,6 @@ data "aws_iam_policy_document" "secret_retrieval_policy_doc" {
 
 resource "aws_iam_policy" "secret_retrieval_policies" {
   count  = "${length(var.environments)}"
-  name   = "${var.namespace}_${var.environments[count.index]}_secret_retrieval"
+  name   = "${var.namespace}-${var.environments[count.index]}-secret_retrieval"
   policy = "${data.aws_iam_policy_document.secret_retrieval_policy_doc.*.json[count.index]}"
 }


### PR DESCRIPTION
Related to enthought/terraform#126

Resolves some of the following errors:

```
* module.brood_staging_stack.aws_security_group.cluster_group_on_specified_vpc: 1 error(s) occurred:

* aws_security_group.cluster_group_on_specified_vpc: Error creating Security Group: InvalidParameterValue: Invalid security group name. Valid names are non-empty strings less than 256 characters from the following set:  a-zA-Z0-9. _-:/()#,@[]+=&;{}!$*
        status code: 400, request id: d7b52495-463a-4181-97b7-090bcaef6d33
* aws_security_group.brood_staging_stack_on_main_vpc (destroy): 1 error(s) occurred:

* aws_security_group.brood_staging_stack_on_main_vpc: DependencyViolation: resource sg-a27df3eb has a dependent object
        status code: 400, request id: d3fccb7a-6632-427d-a455-eeac94b60e79
* module.brood_staging_stack.aws_cloudformation_stack.docker_cluster: 1 error(s) occurred:

* aws_cloudformation_stack.docker_cluster: Creating CloudFormation stack failed: ValidationError: Parameter 'EncryptEFS' must be one of AllowedValues
        status code: 400, request id: 81c7c3da-7586-11e8-912e-41bf444d515e
* module.brood_secret_store.aws_iam_policy.secret_retrieval_policies: 1 error(s) occurred:

* aws_iam_policy.secret_retrieval_policies: Error creating IAM policy brood_staging_secret_retrieval: MalformedPolicyDocument: Statement IDs (SID) must be alpha-numeric. Check that your input satisfies the regular expression [0-9A-Za-z]*
        status code: 400, request id: 81bd8a1d-7586-11e8-861f-4f204f46d212
```

* Interpolated the stack name into a variable with a format string that
had been forgotten - resolves error creating security group
* Converted "yes"/"no" boolean into "true"/"false" for encrypt efs -
resolves error in stack for EncryptEFS parameter
* Converted `_` to `-` in `aws_iam_policy` names for secret retrieval -
resolves MalformedPolicyDocument

Not sure how to resolve the issue of the dependent resource. I am hoping
TF's parallelism will allow that to work on a secondary run, since it
retries quite a few times before it decides it didn't work.