### PR TITLE
FIX: More deployment fixes

### DIFF
--- a/aws_docker_cluster/main.tf
+++ b/aws_docker_cluster/main.tf
@@ -104,6 +104,7 @@ resource "aws_vpc_peering_connection" "cluster_to_specified_vpc" {
   count       = "${var.vpc_peering_configuration["vpc_id"] != "none" ? 1 : 0}"
   vpc_id      = "${var.vpc_peering_configuration["vpc_id"]}"
   peer_vpc_id = "${data.aws_vpc.cluster_vpc.id}"
+  auto_accept = true
 }
 
 data "aws_route_table" "secondary_cluster_table" {
@@ -145,7 +146,7 @@ locals {
 resource "aws_security_group" "cluster_group_on_specified_vpc" {
   count       = "${var.vpc_peering_configuration["vpc_id"] != "none" ? 1 : 0}"
   name        = "${local.peer_vpc_sg_name}"
-  description = "Security group for the '${var.name}' docker cluster"
+  description = "Security group for the ${var.name} docker cluster"
   vpc_id      = "${var.vpc_peering_configuration["vpc_id"]}"
 }
 

--- a/aws_docker_cluster/variables.tf
+++ b/aws_docker_cluster/variables.tf
@@ -134,7 +134,7 @@ variable "manager_disk_type" {
 variable "worker_disk_size" {
   description = "Worker disk size in GiB."
   type        = "string"
-  default     = "standard"
+  default     = "20"
 }
 
 # Should be one of "standard" or "gp2"

--- a/aws_secret_store/main.tf
+++ b/aws_secret_store/main.tf
@@ -66,7 +66,7 @@ data "aws_iam_policy_document" "secret_retrieval_policy_doc" {
   count = "${length(var.environments)}"
 
   statement {
-    sid    = "${var.namespace}_${var.environments[count.index]}_secret_policy"
+    sid    = "${var.namespace}${var.environments[count.index]}SecretPolicy"
     effect = "Allow"
 
     actions = [


### PR DESCRIPTION
Relates to enthought/terraform#126 and enthought/terraform#134

* Updated VPC peering connection to auto-accept, without which the
security group spanning VPCs fails to create properly
* Fixed the default `worker_disk_size` to be `20` instead of `standard`
* Fixed the `SID` of the secret retrieval policy to contain neither
dashes nor underscores

This has already been used to apply the brood staging stack, and so will
be sufficient for a `1.0.0` release.