### PR TITLE
Update Managed_Repository module

### DIFF
--- a/managed_repository/main.tf
+++ b/managed_repository/main.tf
@@ -114,6 +114,9 @@ resource "github_team_membership" "managed_repository-admin" {
   team_id  = "${github_team.managed_repository-internal_admins.id}"
   username = "${var.admin_teams_local[count.index]}"
   role     = "member"
+  lifecycle  {
+    create_before_destroy=true
+  }
 }
 
 resource "github_team_membership" "managed_repository-pull" {
@@ -121,6 +124,9 @@ resource "github_team_membership" "managed_repository-pull" {
   team_id  = "${github_team.managed_repository-internal_pull.id}"
   username = "${var.pull_teams_local[count.index]}"
   role     = "member"
+  lifecycle  {
+    create_before_destroy=true
+  }
 }
 
 resource "github_team_membership" "managed_repository-push" {
@@ -128,6 +134,9 @@ resource "github_team_membership" "managed_repository-push" {
   team_id  = "${github_team.managed_repository-internal_push.id}"
   username = "${var.push_teams_local[count.index]}"
   role     = "member"
+  lifecycle  {
+    create_before_destroy=true
+  }
 }
 
 #######################################################

--- a/managed_repository/vars.tf
+++ b/managed_repository/vars.tf
@@ -122,7 +122,7 @@ variable "repo_has_projects" {
 
 variable "repo_allow_merge_commit" {
   description = "Set This boolean on the repository?"
-  default     = false
+  default     = true
 }
 
 variable "repo_allow_rebase_merge" {


### PR DESCRIPTION
Add lifecycles to githubteam memberships
set merge_commit default to true

The hope/expectation is that the lifecycle change will prevent a team from being removed from a repository once it is empty during the list rebuild cycle when a team member is removed ( pre 0.12 )
