### PR TITLE
Ignore id and auto_init in lifecycle on github_repository resource in managed_repository

### DIFF
--- a/managed_repository/main.tf
+++ b/managed_repository/main.tf
@@ -15,6 +15,11 @@ resource "github_repository" "managed_repository" {
   allow_rebase_merge = "${var.repo_allow_rebase_merge}"
   auto_init          = "${var.repo_auto_init}"
   topics             = "${var.topics}"
+
+  lifecycle {
+    ignore_changes = ["id", "auto_init"]
+  }
+
 }
 
 resource "github_branch_protection" "managed_repository-master_branch_protection" {


### PR DESCRIPTION
Adds lifecycle event ignores to two events that will only trigger when we're importing an existing repository into a module and we do NOT want that to happen.

It's strange that ID woudl ever recompute and auto_init forces a new object no mater it's value.