### PR TITLE
Add Lifecycle constraints to modules

### DIFF
--- a/managed_repository/README.md
+++ b/managed_repository/README.md
@@ -72,3 +72,11 @@ module "MyReop" {
 through lists for user memberships problem.
 * topic names must be lower case. The error thrown does not indicate this is
 the problem.
+
+## Additional Workflow Notes
+
+This CANNOT completely set up Travis-CI and APpVeyor. 
+Add: 
+* The AppVeyor Project
+* The HATCHER_TOKEN environment variable(s)
+  

--- a/managed_repository/main.tf
+++ b/managed_repository/main.tf
@@ -17,7 +17,10 @@ resource "github_repository" "managed_repository" {
   topics             = "${var.topics}"
 
   lifecycle {
-    ignore_changes = ["id", "auto_init"]
+    ignore_changes = [
+      "id", 
+      "auto_init"
+    ]
   }
 
 }

--- a/managed_repository/outputs.tf
+++ b/managed_repository/outputs.tf
@@ -1,0 +1,4 @@
+output "name" {
+    description = "Name of the repository"
+    value = "${github_repository.managed_repository.name}"
+}


### PR DESCRIPTION
We do not want to trigger a rebuild if the auto_init  value changes - this is only a concern when we have imported the repository and it is imported as a null value - so ANY value change forces a resource rebuild - which is unneeded.
